### PR TITLE
Add runtime target detection for pi and omp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # Toilet-Pi
 
-Toilet-Pi is a central web control plane for pi.
+Toilet-Pi is a central web control plane for pi and oh-my-pi.
 
 The easiest way to describe it is:
 
-> It is basically the same idea as pizza, except it has a central server and a pi extension that connects over WebSocket. That means you can interact with all sessions on all machines live, and it also works for normal interactive pi sessions. If you send a message from your phone, the message shows up in the desktop TUI too, so the experience stays seamless.
+> It is basically the same idea as pizza, except it has a central server and a shared extension that connects over WebSocket. That means you can interact with all sessions on all machines live, and it also works for normal interactive pi and oh-my-pi sessions. If you send a message from your phone, the message shows up in the desktop TUI too, so the experience stays seamless.
 
 ## Why this exists
 
-Normal pi sessions live inside one terminal on one machine.
+Normal pi and oh-my-pi sessions live inside one terminal on one machine.
 
 Toilet-Pi adds a thin remote layer on top:
 
 - one **central server** with a web UI
 - one **host supervisor** per machine
-- one **pi extension** that connects interactive and background sessions to the server
+- one **extension** loaded by pi or oh-my-pi that connects interactive and background sessions to the server
 
 That gives you a few nice advantages:
 
 - **See sessions from every machine in one place**
 - **Control already-running interactive sessions remotely**
 - **Resume inactive sessions in background without going back to the desk first**
-- **Send a message from mobile and have it appear inside the real pi TUI**
+- **Send a message from mobile and have it appear inside the real TUI**
 - **Take over a background session locally and make the background runner abort automatically**
 - **Keep the architecture simple**: WebSocket + extension + one lightweight supervisor
 
@@ -34,7 +34,7 @@ There are four pieces:
 The server:
 
 - serves the web UI
-- accepts WebSocket connections from browsers, host supervisors, and pi extensions
+- accepts WebSocket connections from browsers, host supervisors, and pi or oh-my-pi extensions
 - keeps all state in memory
 - tracks the current owner of each session
 - routes messages and aborts to the active owner only
@@ -45,14 +45,14 @@ Each machine runs one long-lived supervisor process.
 
 It:
 
-- scans local pi session files
+- scans local pi and oh-my-pi session files
 - advertises them to the server
-- can start background pi runners on demand
+- can start background runners on demand
 - kills all of its children when it exits
 
-### 3. Interactive pi + extension
+### 3. Interactive pi or oh-my-pi + extension
 
-Normal pi sessions can load `extension.ts`.
+Normal pi and oh-my-pi sessions can load `extension.ts`.
 
 Those sessions:
 
@@ -61,9 +61,9 @@ Those sessions:
 - accept live remote input
 - stay fully usable even if the server is down
 
-### 4. Background pi + same extension
+### 4. Background pi or oh-my-pi + same extension
 
-The supervisor starts headless pi processes in RPC mode, using the same extension.
+The supervisor starts headless pi or oh-my-pi processes in RPC mode, using the same extension.
 
 Those background sessions:
 
@@ -73,24 +73,24 @@ Those background sessions:
 
 ## Ownership model
 
-For each pi session GUID, Toilet-Pi keeps exactly one active command target:
+For each session GUID, Toilet-Pi keeps exactly one active command target:
 
 - `interactive`
 - `background`
 - or `none`
 
-This prevents the web UI from blasting commands at multiple copies of pi at once.
+This prevents the web UI from blasting commands at multiple copies of the runtime at once.
 
 ### Takeover behavior
 
-Interactive pi wins.
+Interactive session wins.
 
 If a session is running in background and you resume it locally:
 
-1. the interactive pi instance connects
+1. the interactive session connects
 2. the server tells the background runner to `abort_and_release`
 3. the background runner aborts and exits
-4. ownership flips to the interactive pi session
+4. ownership flips to the interactive session
 
 That makes local takeover feel natural.
 
@@ -101,20 +101,20 @@ This project intentionally optimizes for simplicity over distributed-systems pur
 ### Things it does on purpose
 
 - **No startup blocking**
-  - pi does not wait for the server to come up
+  - the runtime does not wait for the server to come up
 - **No event-send blocking**
   - server sends are best effort
 - **No database**
   - server state is in memory only
 - **No SDK embedding**
-  - background sessions are just real pi processes in RPC mode
+  - background sessions are just real pi or oh-my-pi processes in RPC mode
 - **No auth or multi-user permissions yet**
   - this is still a focused personal tool
 
 ### Important asymmetry
 
-- **Interactive pi can survive without the server**
-- **Background pi cannot**
+- **Interactive sessions can survive without the server**
+- **Background sessions cannot**
 
 If a background runner loses its server connection, it exits. That avoids hidden orphan writers mutating a session in the dark.
 
@@ -131,15 +131,15 @@ Current capabilities:
 - send a message to an inactive session and have it auto-start in background
 - start a brand-new background session in a project
 - abort the currently active owner
-- take over a background session locally from the normal pi TUI
+- take over a background session locally from the normal TUI
 
 ## Files
 
 - `server/` - TypeScript server subproject for Node.js and Cloudflare Workers
 - `server/public/` - browser UI
-- `extension.ts` - Toilet-Pi pi extension used by interactive and background pi, and the package entrypoint for `pi install`
+- `extension.ts` - Toilet-Pi extension used by interactive and background pi/oh-my-pi sessions; loaded by `pi install` or direct `omp -e` loading
 - `supervisor.js` - one-per-machine supervisor
-- `session-scanner.js` - scans local pi session files
+- `session-scanner.js` - scans local session files
 - `scripts/test-client.js` - raw protocol debug client
 - `docs/quickstart.md` - short setup guide
 - `docs/archive/v2-plan.md` / `docs/archive/v3-plan.md` - archived architecture plans
@@ -168,12 +168,14 @@ Important distinction:
 - **Admin URL / admin token** - browser sign-in only
 - **Machine Connect URL** - used with `/toilet-pi` on one computer
 
-### 3. Configure pi and start the host supervisor
+### 3. Configure pi or oh-my-pi and start the host supervisor
 
 After logging into the web UI, open **Installation** and mint a machine-scoped **Connect URL** for the computer you want to set up.
 
-Inside pi run `/toilet-pi` and paste that machine **Connect URL**.
+For pi, run `/toilet-pi` inside pi and paste that machine **Connect URL**.
 Do **not** paste the browser admin URL into `/toilet-pi`.
+
+For oh-my-pi, load the extension with `omp -e ~/Projects/toilet-pi/extension.ts` or add that path to your configured `extensions` paths. Use the same machine **Connect URL** when the extension prompts.
 
 You can skip the interactive prompt by passing the URL directly:
 
@@ -181,7 +183,7 @@ You can skip the interactive prompt by passing the URL directly:
 /toilet-pi ws://your-server/ws?token=...
 ```
 
-That writes machine-local config to `~/.pi/agent/toilet-pi.json` (respecting `PI_CODING_AGENT_DIR` if set).
+That writes machine-local config to `~/.pi/agent/toilet-pi.json` for pi (respecting `PI_CODING_AGENT_DIR` if set) or `~/.omp/agent/toilet-pi.json` for oh-my-pi.
 
 Then start the host supervisor on that same machine:
 
@@ -190,9 +192,11 @@ cd ~/Projects/toilet-pi
 npm run supervisor
 ```
 
-### 4. Install and run the pi extension
+This advertises local pi and oh-my-pi session files and lets the web UI start background runners when needed.
 
-Recommended: install this repo as a local pi package, then start `pi` normally:
+### 4. Install and run the extension
+
+Recommended for pi users: install this repo as a local pi package, then start `pi` normally:
 
 ```bash
 pi install ~/Projects/toilet-pi
@@ -212,9 +216,17 @@ For one-off testing without installing, load the extension file directly:
 pi -e ~/Projects/toilet-pi/extension.ts
 ```
 
+For oh-my-pi, load the same extension directly:
+
+```bash
+omp -e ~/Projects/toilet-pi/extension.ts
+```
+
+To keep it loaded automatically, add `~/Projects/toilet-pi/extension.ts` to your configured `extensions` paths.
+
 On first run the extension stays unconfigured until you run `/toilet-pi` and give it a machine-scoped **Connect URL** minted from the web UI.
 
-Because local-path installs are used in place, changes in this checkout are picked up after restarting pi or running `/reload`.
+Because the extension loads from a local path, changes in this checkout are picked up after restarting the runtime or running `/reload`.
 
 ### 5. Use the web UI
 
@@ -234,7 +246,7 @@ The Cloudflare deployment only hosts the central server and web UI.
 You still run these locally on each machine you want to control:
 
 - `npm run supervisor`
-- the `extension.ts` pi extension inside `pi`
+- the `extension.ts` extension loaded by `pi` or `omp`
 
 ### 1. Install dependencies
 
@@ -301,7 +313,7 @@ https://toilet-pi.your-subdomain.workers.dev/#token=YOUR_TOKEN
 
 Open the **Admin URL** in your browser.
 
-Then use **Installation** in the web UI to mint a machine-scoped **Connect URL** for each computer you want to set up, and run that inside `pi`:
+Then use **Installation** in the web UI to mint a machine-scoped **Connect URL** for each computer you want to set up, and run that inside the local runtime on that machine:
 
 ```text
 /toilet-pi wss://toilet-pi.your-subdomain.workers.dev/ws?token=...
@@ -364,6 +376,12 @@ pi
 pi -e ~/Projects/toilet-pi/extension.ts
 ```
 
+### Interactive oh-my-pi (direct load)
+
+```bash
+omp -e ~/Projects/toilet-pi/extension.ts
+```
+
 ### Raw debug client
 
 ```bash
@@ -386,21 +404,23 @@ Debug client commands:
 - `TOILET_PI_HOST_ID`
   - default: hostname
 - `TOILET_PI_SESSION_DIR`
-  - default: `~/.pi/agent/sessions`
+  - default: `~/.pi/agent/sessions` for pi, `~/.omp/agent/sessions` for oh-my-pi
 - `PI_CODING_AGENT_DIR`
-  - overrides the base pi agent dir used for `~/.pi/agent/*`
+  - overrides the active runtime's agent dir (`~/.pi/agent/*` or `~/.omp/agent/*`)
 
 ### Server
 
 - `PORT`
   - default: `3457`
+- `HOST`
+  - optional bind host for the Node server; set `0.0.0.0` for direct LAN/VPS access
 - `TOILET_PI_PUBLIC_URL`
-  - optional Node-only public base URL override used when printing the Admin URL on startup
+  - optional Node-only public base URL override used for printed URLs and browser/WebSocket origin checks; set it to the exact browser origin clients use
 
 ### Supervisor
 
 - `TOILET_PI_PI_COMMAND`
-  - default: `pi`
+  - default: `pi` for pi, `omp` for oh-my-pi
 - `TOILET_PI_EXTENSION_PATH`
   - default: local `extension.ts`
 - `TOILET_PI_SCAN_INTERVAL_MS`
@@ -417,11 +437,13 @@ Debug client commands:
 - `TOILET_PI_MESSAGE_LIMIT`
   - max per-message text mirrored to the web UI
 
+For direct LAN access without a reverse proxy, start the Node server with `HOST=0.0.0.0` and `TOILET_PI_PUBLIC_URL=http://<LAN-IP>:3457`, then open that exact origin from other devices. If you want to serve Toilet-Pi at `http://<LAN-IP>/` or behind TLS, use a reverse proxy and forward both `/` and `/ws` to the Node server.
+
 ## Notes
 
 - server state is in-memory only
 - if the server restarts, clients reconnect and rebuild state
-- session identity uses pi's built-in session GUID
+- session identity uses the built-in session GUID
 - the project intentionally keeps the protocol and architecture small
 
 ## License

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,9 +20,12 @@ The server prints:
 
 Open the **Admin URL** in your browser.
 
-## 3. Configure pi and start the host supervisor
+## 3. Configure pi or oh-my-pi and start the host supervisor
 
-Inside pi, run `/toilet-pi` and paste the **Connect URL** printed by the server.
+For pi, run `/toilet-pi` inside pi and paste the **Connect URL** printed by the server.
+Do **not** paste the browser admin URL into `/toilet-pi`.
+
+For oh-my-pi, load the extension with `omp -e /path/to/toilet-pi/extension.ts` or add that path to your configured `extensions` paths. Use the same machine **Connect URL** when the extension prompts.
 
 Or skip the prompt:
 
@@ -30,7 +33,7 @@ Or skip the prompt:
 /toilet-pi ws://your-server/ws?token=...
 ```
 
-That writes config to `~/.pi/agent/toilet-pi.json` (respecting `PI_CODING_AGENT_DIR` if set).
+That writes machine-local config to `~/.pi/agent/toilet-pi.json` for pi (respecting `PI_CODING_AGENT_DIR` if set) or `~/.omp/agent/toilet-pi.json` for oh-my-pi.
 
 Then start the host supervisor:
 
@@ -38,11 +41,11 @@ Then start the host supervisor:
 npm run supervisor
 ```
 
-This advertises local pi session files and lets the web UI start background pi runners when needed.
+This advertises local pi and oh-my-pi session files and lets the web UI start background runners when needed.
 
-## 4. Install and run the pi extension
+## 4. Install and run the extension
 
-Recommended: install this repo as a local pi package, then start `pi` normally:
+Recommended for pi users: install this repo as a local pi package, then start `pi` normally:
 
 ```bash
 pi install ~/Projects/toilet-pi
@@ -62,6 +65,18 @@ One-off testing without installing:
 pi -e ~/Projects/toilet-pi/extension.ts
 ```
 
+For oh-my-pi, load the same extension directly:
+
+```bash
+omp -e ~/Projects/toilet-pi/extension.ts
+```
+
+To keep it loaded automatically, add `~/Projects/toilet-pi/extension.ts` to your configured `extensions` paths.
+
+On first run the extension stays unconfigured until you run `/toilet-pi` and give it a machine-scoped **Connect URL** minted from the web UI.
+
+Because the extension loads from a local path, changes in this checkout are picked up after restarting the runtime or running `/reload`.
+
 ## 5. Use the web UI
 
 The UI has two sidebar views:
@@ -71,9 +86,9 @@ The UI has two sidebar views:
 
 Useful behaviors:
 
-- opening an interactive pi session makes it visible in the browser
+- opening an interactive session makes it visible in the browser
 - sending a message to an inactive session auto-starts it in background
-- starting a new session from **Projects** launches a fresh background pi session in that project
+- starting a new session from **Projects** launches a fresh background session in that project
 - resuming a background-owned session locally makes the background runner abort and release ownership
 
 ## Cloudflare Workers deploy
@@ -132,23 +147,28 @@ The Worker infers its public origin automatically from the incoming request, so 
 
 - Web UI: `http://localhost:3457`
 - WebSocket: `ws://localhost:3457/ws`
-- Local config file: `~/.pi/agent/toilet-pi.json`
+- Local config file: `~/.pi/agent/toilet-pi.json` for pi, `~/.omp/agent/toilet-pi.json` for oh-my-pi
+- Local session dir: `~/.pi/agent/sessions` for pi, `~/.omp/agent/sessions` for oh-my-pi
 
 ## Useful environment variables
 
 ```bash
-PI_CODING_AGENT_DIR=~/.pi/agent
-TOILET_PI_PUBLIC_URL=https://your-server            # optional, Node server only
+PI_CODING_AGENT_DIR=~/.pi/agent            # overrides the active runtime's agent dir (`~/.pi/agent` or `~/.omp/agent`)
+HOST=0.0.0.0                                # optional Node server bind host for LAN/VPS access
+TOILET_PI_PUBLIC_URL=https://your-server    # optional Node-only public base URL; set this to the exact browser origin
 TOILET_PI_SERVER_URL=ws://your-server/ws?token=...  # optional override
 TOILET_PI_HOST_ID=my-machine
-TOILET_PI_SESSION_DIR=/custom/pi/sessions
-TOILET_PI_PI_COMMAND=/path/to/pi
+TOILET_PI_SESSION_DIR=/custom/agent/sessions        # overrides the active runtime's session dir (`~/.pi/agent/sessions` or `~/.omp/agent/sessions`)
+TOILET_PI_PI_COMMAND=/path/to/runtime               # overrides the active runtime command (`pi` or `omp`)
 TOILET_PI_SCAN_INTERVAL_MS=15000
 PORT=3457
 ```
 
+For direct LAN access without a reverse proxy, start the Node server with `HOST=0.0.0.0`, keep the default port, and set `TOILET_PI_PUBLIC_URL` to the exact address clients will use, for example `http://192.168.0.20:3457`. If you want `http://192.168.0.20/` without a port suffix, put a reverse proxy in front of Toilet-Pi and forward both `/` and `/ws`.
+
+
 ## Notes
 
-- interactive pi does not block on server startup or event sends
+- interactive sessions do not block on server startup or event sends
 - background runners are started by `supervisor.js`
 - if a background runner loses the server, it exits

--- a/extension.ts
+++ b/extension.ts
@@ -1,4 +1,6 @@
 import os from "node:os";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { WebSocket } from "ws";
 import type {
   ExtensionAPI,
@@ -6,11 +8,11 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import {
   buildConnectUrl,
+  normalizeConfig,
   parseToiletPiInput,
-  readToiletPiConfig,
   toBrowserBaseUrl,
-  writeToiletPiConfig,
 } from "./toilet-pi-config.js";
+import { resolveRuntimeTarget } from "./runtime-target.js";
 
 const HOST_ID = process.env.TOILET_PI_HOST_ID || os.hostname();
 const ROLE =
@@ -60,6 +62,49 @@ interface ToolCallInfo {
 
 type SanitizedMessage = WebMessage | WebToolResultMessage;
 
+const TOILET_PI_CONFIG_FILE = "toilet-pi.json";
+
+function getHostAgentDir(extensionApi: ExtensionAPI) {
+  try {
+    return (extensionApi as any)?.pi?.getAgentDir?.() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveExtensionRuntimeTarget(extensionApi: ExtensionAPI) {
+  return resolveRuntimeTarget({
+    hostAgentDir: getHostAgentDir(extensionApi),
+  });
+}
+
+function getToiletPiConfigPath(agentDir: string) {
+  return path.join(agentDir, TOILET_PI_CONFIG_FILE);
+}
+
+async function readToiletPiConfig(agentDir: string) {
+  try {
+    const raw = await readFile(getToiletPiConfigPath(agentDir), "utf8");
+    return normalizeConfig(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+async function writeToiletPiConfig(
+  agentDir: string,
+  config: { serverUrl: string; token: string },
+) {
+  const normalized = normalizeConfig(config);
+  await mkdir(agentDir, { recursive: true });
+  await writeFile(
+    getToiletPiConfigPath(agentDir),
+    `${JSON.stringify(normalized, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  return normalized;
+}
+
 export default function (pi: ExtensionAPI) {
   let ws: WebSocket | null = null;
   let reconnectTimer: NodeJS.Timeout | null = null;
@@ -82,6 +127,7 @@ export default function (pi: ExtensionAPI) {
   const pendingToolCalls = new Map<string, ToolCallInfo>();
   const completedToolCalls = new Map<string, ToolCallInfo>();
   const lastToolUpdateTimes = new Map<string, number>();
+  const runtimeTarget = resolveExtensionRuntimeTarget(pi);
 
   function isOpen() {
     return ws?.readyState === WebSocket.OPEN;
@@ -95,7 +141,7 @@ export default function (pi: ExtensionAPI) {
         return null;
       }
     }
-    return readToiletPiConfig();
+    return readToiletPiConfig(runtimeTarget.agentDir);
   }
 
   function getConnectUrl() {
@@ -441,7 +487,7 @@ export default function (pi: ExtensionAPI) {
   async function configureToiletPi(input: string, context: ExtensionContext) {
     const config = parseToiletPiInput(input);
     await verifyConnectionConfig(config);
-    connectionConfig = await writeToiletPiConfig(config);
+    connectionConfig = await writeToiletPiConfig(runtimeTarget.agentDir, config);
     reconnectAttempt = 0;
     shuttingDown = false;
     await connect(true);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "dependencies": {
     "ws": "^8.18.0"
   },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*"
+  },
   "keywords": [
     "pi",
     "pi-package",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,14 @@
       "./extension.ts"
     ]
   },
+  "omp": {
+    "extensions": [
+      "./extension.ts"
+    ]
+  },
   "scripts": {
     "start": "npm start --prefix server",
+    "start:lan": "node scripts/start-lan.js",
     "dev": "npm run dev --prefix server",
     "dev:cf": "npm run dev:cf --prefix server",
     "deploy": "npm run deploy --prefix server",

--- a/runtime-target.js
+++ b/runtime-target.js
@@ -1,0 +1,177 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+export const TOILET_PI_RUNTIMES = Object.freeze({
+  PI: "pi",
+  OMP: "omp",
+});
+
+const ENV_RUNTIME = "TOILET_PI_RUNTIME";
+const ENV_AGENT_DIR = "PI_CODING_AGENT_DIR";
+const ENV_SESSION_DIR = "TOILET_PI_SESSION_DIR";
+const ENV_COMMAND = "TOILET_PI_PI_COMMAND";
+
+const RUNTIME_DEFAULTS = Object.freeze({
+  [TOILET_PI_RUNTIMES.PI]: {
+    configDirName: ".pi",
+    command: "pi",
+  },
+  [TOILET_PI_RUNTIMES.OMP]: {
+    configDirName: ".omp",
+    command: "omp",
+  },
+});
+
+export function expandHomeDir(input, homeDir = homedir()) {
+  const value = String(input || "").trim();
+  if (!value) return null;
+  if (value === "~") return homeDir;
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return path.join(homeDir, value.slice(2));
+  }
+  return value;
+}
+
+export function normalizeRuntime(input) {
+  const value = String(input || "").trim().toLowerCase();
+  if (value === TOILET_PI_RUNTIMES.PI || value === TOILET_PI_RUNTIMES.OMP) {
+    return value;
+  }
+  return null;
+}
+
+export function getRuntimeDefaults(runtime, options = {}) {
+  const normalizedRuntime = normalizeRuntime(runtime);
+  if (!normalizedRuntime) {
+    throw new Error(`Unsupported Toilet-Pi runtime: ${runtime}`);
+  }
+
+  const homeDir = options.homeDir || homedir();
+  const defaults = RUNTIME_DEFAULTS[normalizedRuntime];
+  const agentDir = path.join(homeDir, defaults.configDirName, "agent");
+  return {
+    runtime: normalizedRuntime,
+    agentDir,
+    sessionDir: path.join(agentDir, "sessions"),
+    command: defaults.command,
+  };
+}
+
+export function resolveRuntimeFlavor(options = {}) {
+  const env = options.env || process.env;
+  const homeDir = options.homeDir || homedir();
+  const hostAgentDir = normalizeOptionalPath(options.hostAgentDir);
+  const defaultsByRuntime = {
+    [TOILET_PI_RUNTIMES.PI]: getRuntimeDefaults(TOILET_PI_RUNTIMES.PI, { homeDir }),
+    [TOILET_PI_RUNTIMES.OMP]: getRuntimeDefaults(TOILET_PI_RUNTIMES.OMP, { homeDir }),
+  };
+
+  const explicitRuntime = normalizeRuntime(env[ENV_RUNTIME]);
+  if (explicitRuntime) return explicitRuntime;
+
+  const explicitHint =
+    inferRuntimeFromPath(env[ENV_AGENT_DIR], defaultsByRuntime) ||
+    inferRuntimeFromPath(env[ENV_SESSION_DIR], defaultsByRuntime) ||
+    inferRuntimeFromCommand(env[ENV_COMMAND]);
+  if (explicitHint) return explicitHint;
+
+  const hostRuntime = inferRuntimeFromPath(hostAgentDir, defaultsByRuntime);
+  if (hostRuntime) return hostRuntime;
+
+  const dirExists = options.dirExists || defaultDirExists;
+  const existingAgentDirs = Object.values(TOILET_PI_RUNTIMES).filter((runtime) =>
+    safeBoolean(() => dirExists(defaultsByRuntime[runtime].agentDir)),
+  );
+  if (existingAgentDirs.length === 1) return existingAgentDirs[0];
+
+  const commandExists = options.commandExists || defaultCommandExists;
+  const availableCommands = Object.values(TOILET_PI_RUNTIMES).filter((runtime) =>
+    safeBoolean(() => commandExists(defaultsByRuntime[runtime].command)),
+  );
+  if (availableCommands.length === 1) return availableCommands[0];
+
+  return TOILET_PI_RUNTIMES.PI;
+}
+
+export function resolveRuntimeTarget(options = {}) {
+  const env = options.env || process.env;
+  const homeDir = options.homeDir || homedir();
+  const runtime = resolveRuntimeFlavor({ ...options, env, homeDir });
+  const defaults = getRuntimeDefaults(runtime, { homeDir });
+  const agentDir =
+    expandHomeDir(env[ENV_AGENT_DIR], homeDir) ||
+    normalizeOptionalPath(options.hostAgentDir) ||
+    defaults.agentDir;
+  const sessionDir = expandHomeDir(env[ENV_SESSION_DIR], homeDir) || path.join(agentDir, "sessions");
+  const command = String(env[ENV_COMMAND] || "").trim() || defaults.command;
+
+  return {
+    runtime,
+    agentDir,
+    sessionDir,
+    command,
+  };
+}
+
+function normalizeOptionalPath(input) {
+  const value = String(input || "").trim();
+  return value || null;
+}
+
+function normalizeFsPath(input) {
+  const value = normalizeOptionalPath(input);
+  if (!value) return null;
+  return path.normalize(value).replace(/\\+/g, "/").toLowerCase();
+}
+
+function inferRuntimeFromPath(input, defaultsByRuntime) {
+  const normalizedPath = normalizeFsPath(input);
+  if (!normalizedPath) return null;
+
+  for (const runtime of Object.values(TOILET_PI_RUNTIMES)) {
+    const defaults = defaultsByRuntime[runtime];
+    if (
+      normalizedPath === normalizeFsPath(defaults.agentDir) ||
+      normalizedPath === normalizeFsPath(defaults.sessionDir)
+    ) {
+      return runtime;
+    }
+  }
+
+  if (normalizedPath.endsWith("/.omp/agent") || normalizedPath.endsWith("/.omp/agent/sessions")) {
+    return TOILET_PI_RUNTIMES.OMP;
+  }
+  if (normalizedPath.endsWith("/.pi/agent") || normalizedPath.endsWith("/.pi/agent/sessions")) {
+    return TOILET_PI_RUNTIMES.PI;
+  }
+  return null;
+}
+
+function inferRuntimeFromCommand(input) {
+  const value = String(input || "").trim();
+  if (!value) return null;
+  const baseName = path.basename(value).toLowerCase().replace(/\.(cmd|exe|bat|ps1)$/i, "");
+  if (baseName === TOILET_PI_RUNTIMES.PI) return TOILET_PI_RUNTIMES.PI;
+  if (baseName === TOILET_PI_RUNTIMES.OMP) return TOILET_PI_RUNTIMES.OMP;
+  return null;
+}
+
+function defaultDirExists(dirPath) {
+  return existsSync(dirPath);
+}
+
+function defaultCommandExists(command) {
+  const checker = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(checker, [command], { stdio: "ignore" });
+  return result.status === 0;
+}
+
+function safeBoolean(check) {
+  try {
+    return !!check();
+  } catch {
+    return false;
+  }
+}

--- a/runtime-target.test.js
+++ b/runtime-target.test.js
@@ -1,0 +1,117 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  TOILET_PI_RUNTIMES,
+  expandHomeDir,
+  getRuntimeDefaults,
+  resolveRuntimeTarget,
+} from "./runtime-target.js";
+
+const HOME_DIR = path.join(path.sep, "home", "tester");
+
+test("defaults to pi when runtime is ambiguous", () => {
+  const target = resolveRuntimeTarget({
+    env: {},
+    homeDir: HOME_DIR,
+    dirExists: () => true,
+    commandExists: () => true,
+  });
+
+  assert.deepEqual(target, {
+    runtime: TOILET_PI_RUNTIMES.PI,
+    agentDir: path.join(HOME_DIR, ".pi", "agent"),
+    sessionDir: path.join(HOME_DIR, ".pi", "agent", "sessions"),
+    command: "pi",
+  });
+});
+
+test("selects omp when only omp defaults are available", () => {
+  const ompDefaults = getRuntimeDefaults(TOILET_PI_RUNTIMES.OMP, { homeDir: HOME_DIR });
+  const target = resolveRuntimeTarget({
+    env: {},
+    homeDir: HOME_DIR,
+    dirExists: (candidate) => candidate === ompDefaults.agentDir,
+    commandExists: () => false,
+  });
+
+  assert.deepEqual(target, {
+    runtime: TOILET_PI_RUNTIMES.OMP,
+    agentDir: ompDefaults.agentDir,
+    sessionDir: ompDefaults.sessionDir,
+    command: "omp",
+  });
+});
+
+test("respects TOILET_PI_RUNTIME override", () => {
+  const target = resolveRuntimeTarget({
+    env: { TOILET_PI_RUNTIME: "omp" },
+    homeDir: HOME_DIR,
+    dirExists: () => false,
+    commandExists: () => false,
+  });
+
+  assert.equal(target.runtime, TOILET_PI_RUNTIMES.OMP);
+  assert.equal(target.command, "omp");
+  assert.equal(target.agentDir, path.join(HOME_DIR, ".omp", "agent"));
+  assert.equal(target.sessionDir, path.join(HOME_DIR, ".omp", "agent", "sessions"));
+});
+
+test("uses explicit env overrides for paths and command", () => {
+  const target = resolveRuntimeTarget({
+    env: {
+      PI_CODING_AGENT_DIR: "~/custom-agent",
+      TOILET_PI_SESSION_DIR: "~/custom-sessions",
+      TOILET_PI_PI_COMMAND: "/usr/local/bin/omp",
+    },
+    homeDir: HOME_DIR,
+    dirExists: () => false,
+    commandExists: () => false,
+  });
+
+  assert.deepEqual(target, {
+    runtime: TOILET_PI_RUNTIMES.OMP,
+    agentDir: path.join(HOME_DIR, "custom-agent"),
+    sessionDir: path.join(HOME_DIR, "custom-sessions"),
+    command: "/usr/local/bin/omp",
+  });
+});
+
+test("derives the default session dir from an explicit agent dir", () => {
+  const target = resolveRuntimeTarget({
+    env: {
+      PI_CODING_AGENT_DIR: "~/custom-agent",
+    },
+    homeDir: HOME_DIR,
+    dirExists: () => false,
+    commandExists: () => false,
+  });
+
+  assert.equal(target.runtime, TOILET_PI_RUNTIMES.PI);
+  assert.equal(target.agentDir, path.join(HOME_DIR, "custom-agent"));
+  assert.equal(target.sessionDir, path.join(HOME_DIR, "custom-agent", "sessions"));
+  assert.equal(target.command, "pi");
+});
+
+test("prefers the active host agent dir when provided", () => {
+  const target = resolveRuntimeTarget({
+    env: {},
+    homeDir: HOME_DIR,
+    hostAgentDir: path.join(HOME_DIR, ".omp", "agent"),
+    dirExists: () => false,
+    commandExists: () => false,
+  });
+
+  assert.deepEqual(target, {
+    runtime: TOILET_PI_RUNTIMES.OMP,
+    agentDir: path.join(HOME_DIR, ".omp", "agent"),
+    sessionDir: path.join(HOME_DIR, ".omp", "agent", "sessions"),
+    command: "omp",
+  });
+});
+
+test("expands tilde paths", () => {
+  assert.equal(expandHomeDir("~", HOME_DIR), HOME_DIR);
+  assert.equal(expandHomeDir("~/agent", HOME_DIR), path.join(HOME_DIR, "agent"));
+  assert.equal(expandHomeDir("~\\agent", HOME_DIR), path.join(HOME_DIR, "agent"));
+});

--- a/scripts/start-lan.js
+++ b/scripts/start-lan.js
@@ -1,0 +1,71 @@
+import { networkInterfaces } from "node:os";
+import { spawn } from "node:child_process";
+
+const DEFAULT_PORT = "3457";
+const DEFAULT_HOST = "0.0.0.0";
+
+const port = String(process.env.PORT || DEFAULT_PORT).trim() || DEFAULT_PORT;
+const host = String(process.env.HOST || DEFAULT_HOST).trim() || DEFAULT_HOST;
+const publicUrl =
+  String(process.env.TOILET_PI_PUBLIC_URL || "").trim() ||
+  buildDefaultPublicUrl(port);
+
+const env = {
+  ...process.env,
+  PORT: port,
+  HOST: host,
+  TOILET_PI_PUBLIC_URL: publicUrl,
+};
+
+console.log(`[start:lan] HOST=${env.HOST}`);
+console.log(`[start:lan] PORT=${env.PORT}`);
+console.log(`[start:lan] TOILET_PI_PUBLIC_URL=${env.TOILET_PI_PUBLIC_URL}`);
+
+const npmExecPath = String(process.env.npm_execpath || "").trim();
+const command = npmExecPath ? process.execPath : process.platform === "win32" ? "npm.cmd" : "npm";
+const args = npmExecPath ? [npmExecPath, "start", "--prefix", "server"] : ["start", "--prefix", "server"];
+const child = spawn(command, args, {
+  env,
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+
+child.on("error", (error) => {
+  console.error(`[start:lan] Failed to start server: ${error.message}`);
+  process.exit(1);
+});
+
+function buildDefaultPublicUrl(portValue) {
+  const lanIp = detectLanIpv4();
+  return `http://${lanIp || "localhost"}:${portValue}`;
+}
+
+function detectLanIpv4() {
+  const interfaces = networkInterfaces();
+  const candidates = [];
+
+  for (const entries of Object.values(interfaces)) {
+    for (const entry of entries || []) {
+      if (!entry || entry.family !== "IPv4" || entry.internal) continue;
+      candidates.push(entry.address);
+    }
+  }
+
+  return candidates.find(isPrivateIpv4) || candidates[0] || null;
+}
+
+function isPrivateIpv4(address) {
+  if (address.startsWith("10.")) return true;
+  if (address.startsWith("192.168.")) return true;
+  const match = /^172\.(\d{1,3})\./.exec(address);
+  if (!match) return false;
+  const octet = Number.parseInt(match[1], 10);
+  return Number.isInteger(octet) && octet >= 16 && octet <= 31;
+}

--- a/server/public/app.js
+++ b/server/public/app.js
@@ -503,22 +503,30 @@ function renderInstallation() {
 	const connectUrl = getConnectUrl();
 	installationPanelEl.innerHTML = "";
 
+	const piInstallCommand = "pi install git:https://github.com/mrexodia/toilet-pi";
+	const ompExtensionPath = "/path/to/toilet-pi/extension.ts";
+	const ompLoadCommand = `omp -e ${ompExtensionPath}`;
+
 	const installSection = document.createElement("section");
 	installSection.className = "install-section";
 	const installTitle = document.createElement("div");
 	installTitle.className = "install-copy";
-	installTitle.textContent = "Install package";
+	installTitle.textContent = "Install extension";
+	const installHint = document.createElement("div");
+	installHint.className = "install-hint";
+	installHint.textContent = `pi users can copy the command below. oh-my-pi users can run ${ompLoadCommand} or add ${ompExtensionPath} to their configured extensions path.`;
 	const installActions = document.createElement("div");
 	installActions.className = "install-actions";
 	const installCopyBtn = document.createElement("button");
 	installCopyBtn.type = "button";
-	installCopyBtn.textContent = "Copy";
-	installCopyBtn.onclick = () => copyText(`pi install git:https://github.com/mrexodia/toilet-pi`);
+	installCopyBtn.textContent = "Copy pi command";
+	installCopyBtn.onclick = () => copyText(piInstallCommand);
 	installActions.appendChild(installCopyBtn);
 	const installCode = document.createElement("pre");
 	installCode.className = "install-code";
-	installCode.textContent = "pi install git:https://github.com/mrexodia/toilet-pi";
+	installCode.textContent = `${piInstallCommand}\n${ompLoadCommand}`;
 	installSection.appendChild(installTitle);
+	installSection.appendChild(installHint);
 	installSection.appendChild(installActions);
 	installSection.appendChild(installCode);
 	installationPanelEl.appendChild(installSection);
@@ -777,7 +785,7 @@ function renderBrowserList() {
 function renderSessionBrowser() {
 	const sessions = flattenSessions();
 	if (sessions.length === 0) {
-		browserListEl.appendChild(renderEmpty("No sessions visible yet. Start pi with the websocket extension, or run the host supervisor to discover inactive local sessions."));
+		browserListEl.appendChild(renderEmpty("No sessions visible yet. Start pi or oh-my-pi with the websocket extension, or run the host supervisor to discover inactive local sessions."));
 		return;
 	}
 

--- a/server/src/__tests__/runtime-target.test.ts
+++ b/server/src/__tests__/runtime-target.test.ts
@@ -1,0 +1,118 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  TOILET_PI_RUNTIMES,
+  expandHomeDir,
+  getRuntimeDefaults,
+  resolveRuntimeTarget,
+} from '../node/runtime-target.js'
+
+const HOME_DIR = path.join(path.sep, 'home', 'tester')
+
+describe('resolveRuntimeTarget', () => {
+  it('defaults to pi when runtime is ambiguous', () => {
+    const target = resolveRuntimeTarget({
+      env: {},
+      homeDir: HOME_DIR,
+      dirExists: () => true,
+      commandExists: () => true,
+    })
+
+    expect(target).toEqual({
+      runtime: TOILET_PI_RUNTIMES.PI,
+      agentDir: path.join(HOME_DIR, '.pi', 'agent'),
+      sessionDir: path.join(HOME_DIR, '.pi', 'agent', 'sessions'),
+      command: 'pi',
+    })
+  })
+
+  it('selects omp when only omp defaults are available', () => {
+    const ompDefaults = getRuntimeDefaults(TOILET_PI_RUNTIMES.OMP, { homeDir: HOME_DIR })
+    const target = resolveRuntimeTarget({
+      env: {},
+      homeDir: HOME_DIR,
+      dirExists: candidate => candidate === ompDefaults.agentDir,
+      commandExists: () => false,
+    })
+
+    expect(target).toEqual({
+      runtime: TOILET_PI_RUNTIMES.OMP,
+      agentDir: ompDefaults.agentDir,
+      sessionDir: ompDefaults.sessionDir,
+      command: 'omp',
+    })
+  })
+
+  it('respects TOILET_PI_RUNTIME override', () => {
+    const target = resolveRuntimeTarget({
+      env: { TOILET_PI_RUNTIME: 'omp' },
+      homeDir: HOME_DIR,
+      dirExists: () => false,
+      commandExists: () => false,
+    })
+
+    expect(target.runtime).toBe(TOILET_PI_RUNTIMES.OMP)
+    expect(target.command).toBe('omp')
+    expect(target.agentDir).toBe(path.join(HOME_DIR, '.omp', 'agent'))
+    expect(target.sessionDir).toBe(path.join(HOME_DIR, '.omp', 'agent', 'sessions'))
+  })
+
+  it('uses explicit env overrides for paths and command', () => {
+    const target = resolveRuntimeTarget({
+      env: {
+        PI_CODING_AGENT_DIR: '~/custom-agent',
+        TOILET_PI_SESSION_DIR: '~/custom-sessions',
+        TOILET_PI_PI_COMMAND: '/usr/local/bin/omp',
+      },
+      homeDir: HOME_DIR,
+      dirExists: () => false,
+      commandExists: () => false,
+    })
+
+    expect(target).toEqual({
+      runtime: TOILET_PI_RUNTIMES.OMP,
+      agentDir: path.join(HOME_DIR, 'custom-agent'),
+      sessionDir: path.join(HOME_DIR, 'custom-sessions'),
+      command: '/usr/local/bin/omp',
+    })
+  })
+
+  it('derives the default session dir from an explicit agent dir', () => {
+    const target = resolveRuntimeTarget({
+      env: {
+        PI_CODING_AGENT_DIR: '~/custom-agent',
+      },
+      homeDir: HOME_DIR,
+      dirExists: () => false,
+      commandExists: () => false,
+    })
+
+    expect(target.runtime).toBe(TOILET_PI_RUNTIMES.PI)
+    expect(target.agentDir).toBe(path.join(HOME_DIR, 'custom-agent'))
+    expect(target.sessionDir).toBe(path.join(HOME_DIR, 'custom-agent', 'sessions'))
+    expect(target.command).toBe('pi')
+  })
+
+  it('prefers the active host agent dir when provided', () => {
+    const target = resolveRuntimeTarget({
+      env: {},
+      homeDir: HOME_DIR,
+      hostAgentDir: path.join(HOME_DIR, '.omp', 'agent'),
+      dirExists: () => false,
+      commandExists: () => false,
+    })
+
+    expect(target).toEqual({
+      runtime: TOILET_PI_RUNTIMES.OMP,
+      agentDir: path.join(HOME_DIR, '.omp', 'agent'),
+      sessionDir: path.join(HOME_DIR, '.omp', 'agent', 'sessions'),
+      command: 'omp',
+    })
+  })
+
+  it('expands tilde paths', () => {
+    expect(expandHomeDir('~', HOME_DIR)).toBe(HOME_DIR)
+    expect(expandHomeDir('~/agent', HOME_DIR)).toBe(path.join(HOME_DIR, 'agent'))
+    expect(expandHomeDir('~\\agent', HOME_DIR)).toBe(path.join(HOME_DIR, 'agent'))
+  })
+})

--- a/server/src/node/entry.ts
+++ b/server/src/node/entry.ts
@@ -2,7 +2,6 @@ import { randomBytes, randomUUID } from 'node:crypto'
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { readFile, mkdir, writeFile } from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
-import { homedir } from 'node:os'
 import path from 'node:path'
 import { WebSocketServer, type WebSocket } from 'ws'
 import {
@@ -18,13 +17,16 @@ import {
 } from '../shared/auth.js'
 import { createServerCore } from '../shared/server-core.js'
 import type { ServerConfig, Timers } from '../shared/types.js'
+import { resolveRuntimeTarget } from './runtime-target.js'
 import { createNodeTransport } from './transport.js'
 
 const PORT = Number.parseInt(process.env.PORT || '3457', 10)
+const HOST = String(process.env.HOST || '').trim() || null
 const WS_PATH = process.env.TOILET_PI_WS_PATH || '/ws'
 const PUBLIC_URL = process.env.TOILET_PI_PUBLIC_URL || `http://localhost:${PORT}`
 const PUBLIC_SERVER_URL = getPublicServerUrl(PUBLIC_URL, WS_PATH)
 const PUBLIC_DIR = fileURLToPath(new URL('../../public/', import.meta.url))
+const SERVER_RUNTIME_TARGET = resolveRuntimeTarget()
 const SERVER_TOKEN = await ensureServerToken()
 
 const transport = createNodeTransport()
@@ -149,10 +151,11 @@ wss.on('connection', (ws, req) => {
   })
 })
 
-server.listen(PORT, () => {
+server.listen(PORT, HOST || undefined, () => {
   console.log('='.repeat(60))
   console.log('toilet-pi server')
   console.log('='.repeat(60))
+  console.log(`Bind: ${HOST || '*'}:${PORT}`)
   console.log(`Web UI: ${PUBLIC_URL}`)
   console.log(`WebSocket: ${PUBLIC_SERVER_URL}`)
   console.log(`Admin login URL: ${buildAdminUrl(PUBLIC_SERVER_URL, SERVER_TOKEN)}`)
@@ -358,18 +361,8 @@ function buildAdminUrl(serverUrl: string, token: string): string {
   return url.toString()
 }
 
-function getAgentDir(): string {
-  const envDir = process.env.PI_CODING_AGENT_DIR
-  if (envDir) {
-    if (envDir === '~') return homedir()
-    if (envDir.startsWith('~/')) return path.join(homedir(), envDir.slice(2))
-    return envDir
-  }
-  return path.join(homedir(), '.pi', 'agent')
-}
-
 function getServerStatePath(): string {
-  return path.join(getAgentDir(), 'toilet-pi-server.json')
+  return path.join(SERVER_RUNTIME_TARGET.agentDir, 'toilet-pi-server.json')
 }
 
 async function ensureServerToken(): Promise<string> {
@@ -387,7 +380,7 @@ async function ensureServerToken(): Promise<string> {
   }
 
   const token = randomBytes(32).toString('base64url')
-  await mkdir(getAgentDir(), { recursive: true })
+  await mkdir(SERVER_RUNTIME_TARGET.agentDir, { recursive: true })
   await writeFile(getServerStatePath(), `${JSON.stringify({ token }, null, 2)}\n`, {
     encoding: 'utf8',
     mode: 0o600,

--- a/server/src/node/runtime-target.ts
+++ b/server/src/node/runtime-target.ts
@@ -1,0 +1,200 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import path from 'node:path'
+
+export const TOILET_PI_RUNTIMES = {
+  PI: 'pi',
+  OMP: 'omp',
+} as const
+
+export type ToiletPiRuntime = (typeof TOILET_PI_RUNTIMES)[keyof typeof TOILET_PI_RUNTIMES]
+
+interface ResolveRuntimeTargetOptions {
+  env?: Record<string, string | undefined>
+  homeDir?: string
+  hostAgentDir?: string | null
+  dirExists?: (dirPath: string) => boolean
+  commandExists?: (command: string) => boolean
+}
+
+interface RuntimeDefaults {
+  runtime: ToiletPiRuntime
+  agentDir: string
+  sessionDir: string
+  command: string
+}
+
+const ENV_RUNTIME = 'TOILET_PI_RUNTIME'
+const ENV_AGENT_DIR = 'PI_CODING_AGENT_DIR'
+const ENV_SESSION_DIR = 'TOILET_PI_SESSION_DIR'
+const ENV_COMMAND = 'TOILET_PI_PI_COMMAND'
+
+const RUNTIME_DEFAULTS: Record<ToiletPiRuntime, { configDirName: string; command: string }> = {
+  [TOILET_PI_RUNTIMES.PI]: {
+    configDirName: '.pi',
+    command: 'pi',
+  },
+  [TOILET_PI_RUNTIMES.OMP]: {
+    configDirName: '.omp',
+    command: 'omp',
+  },
+}
+
+export function expandHomeDir(input: string | undefined | null, homeDir: string = homedir()): string | null {
+  const value = String(input || '').trim()
+  if (!value) return null
+  if (value === '~') return homeDir
+  if (value.startsWith('~/') || value.startsWith('~\\')) {
+    return path.join(homeDir, value.slice(2))
+  }
+  return value
+}
+
+export function normalizeRuntime(input: string | undefined | null): ToiletPiRuntime | null {
+  const value = String(input || '').trim().toLowerCase()
+  if (value === TOILET_PI_RUNTIMES.PI || value === TOILET_PI_RUNTIMES.OMP) {
+    return value
+  }
+  return null
+}
+
+export function getRuntimeDefaults(
+  runtime: ToiletPiRuntime | string,
+  options: Pick<ResolveRuntimeTargetOptions, 'homeDir'> = {},
+): RuntimeDefaults {
+  const normalizedRuntime = normalizeRuntime(runtime)
+  if (!normalizedRuntime) {
+    throw new Error(`Unsupported Toilet-Pi runtime: ${runtime}`)
+  }
+
+  const homeDir = options.homeDir || homedir()
+  const defaults = RUNTIME_DEFAULTS[normalizedRuntime]
+  const agentDir = path.join(homeDir, defaults.configDirName, 'agent')
+  return {
+    runtime: normalizedRuntime,
+    agentDir,
+    sessionDir: path.join(agentDir, 'sessions'),
+    command: defaults.command,
+  }
+}
+
+export function resolveRuntimeFlavor(options: ResolveRuntimeTargetOptions = {}): ToiletPiRuntime {
+  const env = options.env || process.env
+  const homeDir = options.homeDir || homedir()
+  const hostAgentDir = normalizeOptionalPath(options.hostAgentDir)
+  const defaultsByRuntime: Record<ToiletPiRuntime, RuntimeDefaults> = {
+    [TOILET_PI_RUNTIMES.PI]: getRuntimeDefaults(TOILET_PI_RUNTIMES.PI, { homeDir }),
+    [TOILET_PI_RUNTIMES.OMP]: getRuntimeDefaults(TOILET_PI_RUNTIMES.OMP, { homeDir }),
+  }
+
+  const explicitRuntime = normalizeRuntime(env[ENV_RUNTIME])
+  if (explicitRuntime) return explicitRuntime
+
+  const explicitHint =
+    inferRuntimeFromPath(env[ENV_AGENT_DIR], defaultsByRuntime) ||
+    inferRuntimeFromPath(env[ENV_SESSION_DIR], defaultsByRuntime) ||
+    inferRuntimeFromCommand(env[ENV_COMMAND])
+  if (explicitHint) return explicitHint
+
+  const hostRuntime = inferRuntimeFromPath(hostAgentDir, defaultsByRuntime)
+  if (hostRuntime) return hostRuntime
+
+  const dirExists = options.dirExists || defaultDirExists
+  const existingAgentDirs = Object.values(TOILET_PI_RUNTIMES).filter(runtime =>
+    safeBoolean(() => dirExists(defaultsByRuntime[runtime].agentDir)),
+  )
+  if (existingAgentDirs.length === 1) return existingAgentDirs[0]
+
+  const commandExists = options.commandExists || defaultCommandExists
+  const availableCommands = Object.values(TOILET_PI_RUNTIMES).filter(runtime =>
+    safeBoolean(() => commandExists(defaultsByRuntime[runtime].command)),
+  )
+  if (availableCommands.length === 1) return availableCommands[0]
+
+  return TOILET_PI_RUNTIMES.PI
+}
+
+export function resolveRuntimeTarget(options: ResolveRuntimeTargetOptions = {}): RuntimeDefaults {
+  const env = options.env || process.env
+  const homeDir = options.homeDir || homedir()
+  const runtime = resolveRuntimeFlavor({ ...options, env, homeDir })
+  const defaults = getRuntimeDefaults(runtime, { homeDir })
+  const agentDir =
+    expandHomeDir(env[ENV_AGENT_DIR], homeDir) ||
+    normalizeOptionalPath(options.hostAgentDir) ||
+    defaults.agentDir
+  const sessionDir = expandHomeDir(env[ENV_SESSION_DIR], homeDir) || path.join(agentDir, 'sessions')
+  const command = String(env[ENV_COMMAND] || '').trim() || defaults.command
+
+  return {
+    runtime,
+    agentDir,
+    sessionDir,
+    command,
+  }
+}
+
+function normalizeOptionalPath(input: string | undefined | null): string | null {
+  const value = String(input || '').trim()
+  return value || null
+}
+
+function normalizeFsPath(input: string | undefined | null): string | null {
+  const value = normalizeOptionalPath(input)
+  if (!value) return null
+  return path.normalize(value).replace(/\\+/g, '/').toLowerCase()
+}
+
+function inferRuntimeFromPath(
+  input: string | undefined | null,
+  defaultsByRuntime: Record<ToiletPiRuntime, RuntimeDefaults>,
+): ToiletPiRuntime | null {
+  const normalizedPath = normalizeFsPath(input)
+  if (!normalizedPath) return null
+
+  for (const runtime of Object.values(TOILET_PI_RUNTIMES)) {
+    const defaults = defaultsByRuntime[runtime]
+    if (
+      normalizedPath === normalizeFsPath(defaults.agentDir) ||
+      normalizedPath === normalizeFsPath(defaults.sessionDir)
+    ) {
+      return runtime
+    }
+  }
+
+  if (normalizedPath.endsWith('/.omp/agent') || normalizedPath.endsWith('/.omp/agent/sessions')) {
+    return TOILET_PI_RUNTIMES.OMP
+  }
+  if (normalizedPath.endsWith('/.pi/agent') || normalizedPath.endsWith('/.pi/agent/sessions')) {
+    return TOILET_PI_RUNTIMES.PI
+  }
+  return null
+}
+
+function inferRuntimeFromCommand(input: string | undefined | null): ToiletPiRuntime | null {
+  const value = String(input || '').trim()
+  if (!value) return null
+  const baseName = path.basename(value).toLowerCase().replace(/\.(cmd|exe|bat|ps1)$/i, '')
+  if (baseName === TOILET_PI_RUNTIMES.PI) return TOILET_PI_RUNTIMES.PI
+  if (baseName === TOILET_PI_RUNTIMES.OMP) return TOILET_PI_RUNTIMES.OMP
+  return null
+}
+
+function defaultDirExists(dirPath: string): boolean {
+  return existsSync(dirPath)
+}
+
+function defaultCommandExists(command: string): boolean {
+  const checker = process.platform === 'win32' ? 'where' : 'which'
+  const result = spawnSync(checker, [command], { stdio: 'ignore' })
+  return result.status === 0
+}
+
+function safeBoolean(check: () => boolean): boolean {
+  try {
+    return !!check()
+  } catch {
+    return false
+  }
+}

--- a/session-scanner.js
+++ b/session-scanner.js
@@ -1,8 +1,8 @@
 import { createReadStream } from "node:fs";
 import { access, readdir, stat } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
 import readline from "node:readline";
+import { resolveRuntimeTarget } from "./runtime-target.js";
 
 const DEFAULT_MESSAGE_LIMIT = Number.parseInt(
   process.env.TOILET_PI_MESSAGE_LIMIT || "4000",
@@ -10,10 +10,7 @@ const DEFAULT_MESSAGE_LIMIT = Number.parseInt(
 );
 
 export function getDefaultSessionDir() {
-  return (
-    process.env.TOILET_PI_SESSION_DIR ||
-    path.join(homedir(), ".pi", "agent", "sessions")
-  );
+  return resolveRuntimeTarget().sessionDir;
 }
 
 export async function scanSessions(sessionDir = getDefaultSessionDir()) {

--- a/supervisor.js
+++ b/supervisor.js
@@ -11,14 +11,13 @@ import {
 } from "./toilet-pi-config.js";
 import {
   findSessionFile,
-  getDefaultSessionDir,
   readSessionSnapshot,
   scanSessions,
 } from "./session-scanner.js";
+import { resolveRuntimeTarget } from "./runtime-target.js";
 
 const HOST_ID = process.env.TOILET_PI_HOST_ID || os.hostname();
-const PI_COMMAND = process.env.TOILET_PI_PI_COMMAND || "pi";
-const SESSION_DIR = process.env.TOILET_PI_SESSION_DIR || getDefaultSessionDir();
+const { command: PI_COMMAND, sessionDir: SESSION_DIR } = resolveRuntimeTarget();
 const SCAN_INTERVAL_MS = Number.parseInt(
   process.env.TOILET_PI_SCAN_INTERVAL_MS || "15000",
   10,
@@ -278,9 +277,7 @@ function startBackgroundRunner(message) {
   if (!createNew && sessionRef) {
     args.push("--session", sessionRef);
   }
-  if (process.env.TOILET_PI_SESSION_DIR) {
-    args.push("--session-dir", SESSION_DIR);
-  }
+  args.push("--session-dir", SESSION_DIR);
 
   log(
     `starting background runner (${createNew ? "new" : message.sessionGuid})`,

--- a/toilet-pi-config.js
+++ b/toilet-pi-config.js
@@ -1,21 +1,13 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import path from "node:path";
+import { resolveRuntimeTarget } from "./runtime-target.js";
 
-const CONFIG_DIR_NAME = ".pi";
-const ENV_AGENT_DIR = "PI_CODING_AGENT_DIR";
 const TOILET_PI_CONFIG_FILE = "toilet-pi.json";
 const TOILET_PI_SERVER_STATE_FILE = "toilet-pi-server.json";
 
 export function getAgentDir() {
-  const envDir = process.env[ENV_AGENT_DIR];
-  if (envDir) {
-    if (envDir === "~") return homedir();
-    if (envDir.startsWith("~/")) return path.join(homedir(), envDir.slice(2));
-    return envDir;
-  }
-  return path.join(homedir(), CONFIG_DIR_NAME, "agent");
+  return resolveRuntimeTarget().agentDir;
 }
 
 export function getToiletPiConfigPath() {


### PR DESCRIPTION
## Summary
- detect whether Toilet Pi should target the pi or omp runtime from environment, host agent paths, default install locations, and available commands
- thread the resolved runtime target through the extension, server entrypoint, supervisor, and session scanner, and add a LAN start helper plus documentation updates
- add runtime-target coverage in both the root Node test suite and the server Vitest suite, and declare the pi-coding-agent peer dependency

## Verification
- node --test runtime-target.test.js
- npm test --prefix server -- src/__tests__/runtime-target.test.ts
- npm run check --prefix server